### PR TITLE
UI: Fix overlap between search banner search results and nav container

### DIFF
--- a/scss/search-banner.scss
+++ b/scss/search-banner.scss
@@ -75,6 +75,9 @@
   .search-menu .searching .d-icon {
     color: var(--search-color);
   }
+  .panel-body {
+    z-index: z("dropdown");
+  }
   .results {
     background: var(--d-content-background);
   }


### PR DESCRIPTION
This PR fixes the z-index overlap issue with the search results of the search-banner component and navigation-container.

Before (local testing):

![CleanShot 2025-03-01 at 12 13 14@2x](https://github.com/user-attachments/assets/970926c0-b433-43df-a537-50b2b6d50718)

After (local testing):

![CleanShot 2025-03-01 at 12 16 37@2x](https://github.com/user-attachments/assets/bd496363-08e0-4101-8c59-a5533b9ec222)

Dev:

![CleanShot 2025-03-01 at 12 17 12@2x](https://github.com/user-attachments/assets/df052ee8-623d-48af-93ed-1fcd9e569970)

