### PR TITLE
UI: fix overlap composer

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,4 +1,5 @@
 @import "buttons";
+@import "compose";
 @import "header";
 @import "hiddenstuff";
 @import "main";

--- a/scss/compose.scss
+++ b/scss/compose.scss
@@ -1,0 +1,3 @@
+#reply-control {
+  z-index: 999;
+}


### PR DESCRIPTION
Fix overlap with topic title and composer.

Before:

![CleanShot 2025-03-03 at 12 12 59@2x](https://github.com/user-attachments/assets/cfc8d893-f5c6-4b05-8a36-b2865248e212)

After:

![CleanShot 2025-03-03 at 12 15 37@2x](https://github.com/user-attachments/assets/ebd9f8c5-07c6-4cbf-afcc-dc445bfc924f)

