### PR TITLE
UX: More desktop tweaks

### DIFF
--- a/about.json
+++ b/about.json
@@ -1,5 +1,5 @@
 {
-  "name": "next-gen",
+  "name": "Horizon Theme",
   "authors": "Design Team",
   "about_url": "TODO: Put your theme's public repo or Meta topic URL here",
   "license_url": "TODO: Put your theme's LICENSE URL here",
@@ -17,7 +17,7 @@
     "https://github.com/discourse/discourse-full-width-component.git"
   ],
   "color_schemes": {
-    "next_gen": {
+    "Horizon": {
       "primary": "1A1A1A",
       "primary-low": "ebecf9",
       "primary-500": "8591ad",
@@ -29,7 +29,7 @@
       "selected": "d8d9f3",
       "hover": "ebebf9"
     },
-    "next_gen_dark": {
+    "Horizon Dark": {
       "primary": "F1EFF9",
       "secondary": "1e1a36",
       "header_background": "00091d",

--- a/scss/box-view.scss
+++ b/scss/box-view.scss
@@ -5,6 +5,18 @@
   }
 }
 
+.chat-drawer-active.chat-drawer-expanded {
+  .experimental-screen {
+    &__top-left,
+    &__top-right,
+    &__bottom-left,
+    &__bottom-right,
+    &__bottom-bar {
+      z-index: 199;
+    }
+  }
+}
+
 .has-full-page-chat .experimental-screen {
   display: none;
 }

--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -34,9 +34,8 @@
   }
 }
 
-.btn-default,
-.select-kit .select-kit-header {
-  border: 1px solid var(--accent-color);
+.btn-default {
+  border: 1px solid var(--primary-300);
   //id like to use rgba of the accent colour but how to derive that?
   // box-shadow: 0px 0px 8px 2px oklch(from (var(--accent-color)) calc(l * 2) calc(c * 0.125) h);
   background: var(--secondary);
@@ -46,8 +45,9 @@
   }
   &:hover {
     .discourse-no-touch & {
-      border: 1px solid transparent;
-      box-shadow: 0px 0px 8px 2px rgba(0, 0, 0, 0.1);
+      border: 1px solid var(--accent-color);
+      box-shadow: 0px 0px 8px 2px
+        oklch(from (var(--accent-color)) calc(l * 2) calc(c * 0.125) h);
       background: var(--secondary);
       color: var(--accent-color);
       .d-icon {

--- a/scss/chat.scss
+++ b/scss/chat.scss
@@ -9,7 +9,7 @@
 .c-navbar-container {
   border-top-left-radius: var(--d-border-radius-large);
   border-top-right-radius: var(--d-border-radius-large);
-  padding: 0 1.5rem;
+  padding: 0 1.5em;
   background-color: var(--d-content-background);
 }
 

--- a/scss/chat.scss
+++ b/scss/chat.scss
@@ -1,5 +1,6 @@
 .full-page-chat.full-page-chat-sidebar-enabled {
   border-top-left-radius: var(--d-border-radius-large);
+  border-top-right-radius: var(--d-border-radius-large);
   box-shadow: 0px 0px 1px 2px var(--tertiary-100),
     0px 0px 24px 4px var(--tertiary-100);
   border: none;
@@ -7,6 +8,7 @@
 
 .c-navbar-container {
   border-top-left-radius: var(--d-border-radius-large);
+  border-top-right-radius: var(--d-border-radius-large);
   padding: 0 1.5rem;
   background-color: var(--d-content-background);
 }

--- a/scss/chat.scss
+++ b/scss/chat.scss
@@ -1,8 +1,10 @@
 .full-page-chat.full-page-chat-sidebar-enabled {
   border-top-left-radius: var(--d-border-radius-large);
   border-top-right-radius: var(--d-border-radius-large);
-  box-shadow: 0px 0px 1px 2px var(--tertiary-100),
-    0px 0px 24px 4px var(--tertiary-100);
+  box-shadow: 0px 0px 0px 2px
+      oklch(from var(--accent-color) calc(l * 2) calc(c * 0.125) h),
+    0px 0px 8px 2px
+      oklch(from var(--accent-color) calc(l * 2) calc(c * 0.125) h);
   border: none;
 }
 
@@ -15,4 +17,27 @@
 
 body.has-full-page-chat {
   background-color: var(--background-color);
+}
+
+.chat-drawer .chat-drawer-container {
+  box-shadow: 0px 0px 0px 2px
+      oklch(from var(--accent-color) calc(l * 2) calc(c * 0.125) h),
+    0px 0px 8px 2px
+      oklch(from var(--accent-color) calc(l * 2) calc(c * 0.125) h);
+  border: none;
+}
+
+.chat-drawer .channels-list-container .chat-channel-row {
+  margin-bottom: var(--spacing-block-xs);
+  font-size: var(--font-up-1);
+  border-radius: var(--d-border-radius);
+  &:hover {
+    background-color: var(--d-sidebar-active-background);
+  }
+}
+
+.channel-title {
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: var(--font-down-1);
 }

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -6,6 +6,17 @@ html:not(:has(.has-full-page-chat)) {
   --main-grid-gap: 2em;
 }
 
+body.has-sidebar-page.has-full-page-chat #main-outlet-wrapper {
+  grid-column-gap: var(--main-grid-gap);
+}
+
+body.has-full-page-chat #main-outlet-wrapper {
+  grid-template-columns: 1fr minmax(0, var(--d-max-width)) 1fr;
+  #main-outlet {
+    max-width: var(--d-max-width);
+  }
+}
+
 body:not(.has-full-page-chat) {
   background-color: var(--background-color);
   #main-outlet-wrapper {

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -45,7 +45,8 @@ body:not(.has-full-page-chat) {
       .discourse-post-event-upcoming-events,
       .container.groups-index,
       .body-page,
-      .container.badges {
+      .container.badges,
+      .topic-above-footer-buttons-outlet .presence-users {
         max-width: 1000px;
         margin-inline: auto;
         padding-inline: 1.5em;

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -11,10 +11,7 @@ body.has-sidebar-page.has-full-page-chat #main-outlet-wrapper {
 }
 
 body.has-full-page-chat #main-outlet-wrapper {
-  grid-template-columns: 1fr minmax(0, var(--d-max-width)) 1fr;
-  #main-outlet {
-    max-width: var(--d-max-width);
-  }
+  grid-template-columns: var(--d-sidebar-width) 1fr 0px;
 }
 
 body:not(.has-full-page-chat) {

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -10,8 +10,11 @@ body.has-sidebar-page.has-full-page-chat #main-outlet-wrapper {
   grid-column-gap: var(--main-grid-gap);
 }
 
-body.has-full-page-chat #main-outlet-wrapper {
+body.has-sidebar-page #main-outlet-wrapper {
   grid-template-columns: var(--d-sidebar-width) 1fr 0px;
+  #main-outlet {
+    max-width: unset;
+  }
 }
 
 body:not(.has-full-page-chat) {

--- a/scss/nav-pills.scss
+++ b/scss/nav-pills.scss
@@ -12,13 +12,15 @@
       order: 1;
     }
   }
-  .combo-box .combo-box-header,
-  .discourse-post-event .discourse-post-event-widget {
+  .combo-box .combo-box-header {
     // needs more specificy than just in the button file
     background-color: var(--secondary);
-    border: 1px solid var(--accent-color);
     border-radius: var(--d-border-radius-large);
+    border: 1px solid var(--primary-300);
     // font-size: var(--font-up-1-rem);
+    &:hover {
+      border: 1px solid var(--accent-color);
+    }
   }
   .select-kit.combo-box.category-drop.has-selection
     .category-drop-header:hover {

--- a/scss/nav-pills.scss
+++ b/scss/nav-pills.scss
@@ -20,6 +20,8 @@
     // font-size: var(--font-up-1-rem);
     &:hover {
       border: 1px solid var(--accent-color);
+      box-shadow: 0px 0px 8px 2px
+        oklch(from (var(--accent-color)) calc(l * 2) calc(c * 0.125) h);
     }
   }
   .select-kit.combo-box.category-drop.has-selection

--- a/scss/sidebar.scss
+++ b/scss/sidebar.scss
@@ -15,8 +15,11 @@
     // dont want to change fonts here just yet as font-size can be changed as a user pref.
     // – charlie: sure but I want it to be bigger by default
     // letter-spacing: 0.5px;
-    border-radius: 10px; // visually somewhat consistent with border on main outlet (?)
     transition: none;
+    border-radius: var(--d-border-radius);
+  }
+  .dropdown-menu__item .sidebar-section-link {
+    border-radius: 0px;
   }
 }
 .sidebar-section-wrapper {

--- a/scss/topic.scss
+++ b/scss/topic.scss
@@ -62,6 +62,23 @@
   padding: 0 24px;
 }
 
+.container.posts {
+  grid-template-columns: auto 150px;
+  @media screen and (max-width: 924px) {
+    grid-template-columns: auto auto;
+  }
+}
+
+.timeline-container .topic-timeline .timeline-ago {
+  max-width: unset;
+  overflow: unset;
+  text-overflow: unset;
+}
+
+.timeline-container .topic-timeline .timeline-scroller-content {
+  overflow: unset;
+}
+
 .more-topics__container
   .more-topics__list
   .topic-list-body

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -1,5 +1,6 @@
 :root {
   color-scheme: light dark;
+  --d-max-width: 1000px;
   --d-border-radius-large: 20px;
   --d-border-radius: 8px;
   --d-input-border-radius: 6px;


### PR DESCRIPTION
This PR:

- Renames theme to "Horizon"
- aligns button & hover status to match other elements
- adjusts problems with the boxed view
- adjusts box shadow to use variation of accent color using oklch
- adjusts with of chat / topic list / topic box & sets content to not go past max-width
- styles chat drawer to match some sidebar styles
- small additions to get padding correctly applied to containers
- adjustment to timeline width to keep content viewable

| before | after |
| -- | -- |
| ![CleanShot 2025-03-06 at 12 47 18@2x](https://github.com/user-attachments/assets/045fa947-25da-4e6c-a7ab-6216e4e04a73) | ![CleanShot 2025-03-06 at 12 42 39@2x](https://github.com/user-attachments/assets/48bf88ff-0266-402d-8aec-6ae14ccf3eca) |
|![CleanShot 2025-03-06 at 12 47 01@2x](https://github.com/user-attachments/assets/d570dbcc-cdfb-44a2-ab43-8c45d3e9ab2a)|![CleanShot 2025-03-06 at 12 44 17@2x](https://github.com/user-attachments/assets/1ebd3185-737d-46a4-ac4a-8158b1ecd13d)|
|![CleanShot 2025-03-06 at 12 46 14@2x](https://github.com/user-attachments/assets/385422f4-be7f-465a-9337-70e072d51067)| ![CleanShot 2025-03-06 at 12 44 35@2x](https://github.com/user-attachments/assets/cf289964-dc51-488e-9e74-0fd90138634b)|
|![CleanShot 2025-03-06 at 12 45 49@2x](https://github.com/user-attachments/assets/8fe0fbc2-83e7-476f-a1e2-d981377fe40f)| ![CleanShot 2025-03-06 at 12 45 10@2x](https://github.com/user-attachments/assets/09bd637d-43cd-4102-9ce6-ec3fd5ae3d2a)|
